### PR TITLE
Release v0.2.1: PyPI/RTD links + version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
   <img src="https://raw.githubusercontent.com/crow-intelligence/chronowords/main/img/chronowords.svg" alt="chronowords" width="450"/>
 </p>
 
+<p align="center">
+  <a href="https://pypi.org/project/chronowords/"><img src="https://img.shields.io/pypi/v/chronowords.svg" alt="PyPI"></a>
+  <a href="https://chronowords.readthedocs.io/en/latest/"><img src="https://img.shields.io/readthedocs/chronowords" alt="Docs"></a>
+</p>
+
 # chronowords
 
 Detect semantic shifts over time in word embeddings. Train small PPMI-based language models, create topic models using NMF, and analyze semantic changes using Procrustes alignment.
@@ -38,8 +43,9 @@ topic_model = TopicModel(n_topics=10)
 topic_model.fit(ppmi_matrix, vocabulary)
 ```
 
-## Documentation
-Full documentation available at ReadTheDocs.
+## Links
+- Documentation: <https://chronowords.readthedocs.io/en/latest/>
+- PyPI: <https://pypi.org/project/chronowords/>
 
 ## Requirements
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@ sys.path.insert(0, file_path)
 project = "chronowords"
 copyright = "2024, Crow Intelligence"
 author = "Orsolya Putz, Zoltan Varju"
-release = "0.1.1"
+release = "0.2.1"
 
 # General configuration
 extensions = [

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,8 @@ shift over time using the Procrustes method.
 
 Built and maintained by `Crow Intelligence <https://crowintelligence.org/>`_.
 
+Install from `PyPI <https://pypi.org/project/chronowords/>`_.
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chronowords"
-version = "0.2.0"
+version = "0.2.1"
 description = "Detect semantic shifts in word embeddings over time"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/crow-intelligence/chronowords"
 Repository = "https://github.com/crow-intelligence/chronowords"
-Documentation = "https://chronowords.readthedocs.io"
+Documentation = "https://chronowords.readthedocs.io/en/latest/"
 Organization = "https://crowintelligence.org/"
 
 [dependency-groups]


### PR DESCRIPTION
## Summary
- Adds PyPI + RTD badges and a Links section to the README so the package's distribution points are discoverable from every surface.
- Adds a PyPI install pointer on the RTD landing page.
- Updates `project.urls` Documentation to the canonical `/en/latest/` URL so PyPI's sidebar link resolves directly.
- Bumps version to `0.2.1` (and syncs the stale `docs/source/conf.py` release, which was still at `0.1.1`).

## Test plan
- [x] Ruff + pytest pass locally (48 tests)
- [ ] CI green on this PR
- [ ] After merge: tag `v0.2.1`, publish GitHub Release, confirm PyPI shows 0.2.1 and RTD rebuilds

🤖 Generated with [Claude Code](https://claude.com/claude-code)