### PR TITLE
Fix publish workflow: sdist only, drop unreachable RTD curl

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,9 +21,5 @@ jobs:
 
       - name: Build and publish
         run: |
-          uv build
+          uv build --sdist
           uv publish --token ${{ secrets.PYPI_TOKEN }}
-
-      - name: Trigger RTD build
-        run: |
-          curl -X POST -d "branches=main" -d "token=${{ secrets.RTD_WEBHOOK_TOKEN }}" https://readthedocs.org/api/v2/webhook/chronowords/0/


### PR DESCRIPTION
## Summary
- `uv build` → `uv build --sdist` so the workflow stops failing on wheel upload.
- Remove the unreachable `Trigger RTD build` step. It ran after `uv publish`, which now always fails on the wheel, and RTD's own GitHub integration already rebuilds on push and tag.

## Context
During the v0.2.1 release, `uv publish` aborted with:

> \`400 Binary wheel 'chronowords-0.2.1-cp312-cp312-linux_x86_64.whl' has an unsupported platform tag 'linux_x86_64'.\`

The sdist uploaded successfully before the wheel attempt, so the release went through in practice — the job just exited non-zero and skipped everything after it. Sdist-only matches that working behavior; pip continues to build the Cython extension from sdist on install. Upgrading to proper \`manylinux\` wheels via cibuildwheel is an independent change for a later PR.

The \`RTD_WEBHOOK_TOKEN\` repo secret is now unused and can be deleted from Settings → Secrets when convenient.

## Test plan
- [ ] Merge and observe next release: the Publish workflow should end green.
- [ ] PyPI receives the sdist for the next version as usual.
- [ ] RTD's \`latest\` and \`stable\` rebuild on merge/tag via its own integration (already verified during v0.2.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)