### PR TITLE
Docs overhaul: contract docstrings + rebuilt quickstart/tutorials/troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,26 @@ pip install chronowords
 from chronowords.algebra import SVDAlgebra
 from chronowords.topics import TopicModel
 
-# Train word embeddings
+# Train word embeddings on any iterable of text lines
+# (a list, a generator, or an open file).
 model = SVDAlgebra(n_components=300)
-model.train(your_corpus_iterator)
+with open("corpus.txt", encoding="utf-8") as fh:
+    model.train(fh)
 
 # Find similar words
-similar = model.most_similar('computer')
-for word in similar:
-    print(f"{word.word}: {word.similarity:.3f}")
+for hit in model.most_similar("computer", n=10):
+    print(f"{hit.word}: {hit.similarity:.3f}")
 
-# Create topic model
+# Topic model over the PPMI matrix that train() computed
 topic_model = TopicModel(n_topics=10)
-topic_model.fit(ppmi_matrix, vocabulary)
+topic_model.fit(model._ppmi_sparse, model.vocabulary)
+topic_model.print_topics()
 ```
+
+See the [quickstart](https://chronowords.readthedocs.io/en/latest/quickstart.html)
+for a complete runnable example and the
+[tutorial](https://chronowords.readthedocs.io/en/latest/tutorial.html) for
+detecting semantic shift across time slices.
 
 ## Links
 - Documentation: <https://chronowords.readthedocs.io/en/latest/>

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
 sphinx>=8.1.3
 sphinx-rtd-theme>=3.0.2
-sphinx-autodoc-typehints>=3.0.1

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,26 +1,34 @@
 API Reference
-============
+=============
 
 Word Embeddings
--------------
+---------------
 .. automodule:: chronowords.algebra.svd
    :members:
    :show-inheritance:
 
 Alignment
---------
+---------
 .. automodule:: chronowords.alignment.procrustes
    :members:
    :show-inheritance:
 
 Topic Modeling
-------------
+--------------
 .. automodule:: chronowords.topics.nmf
    :members:
    :show-inheritance:
 
 Utilities
---------
+---------
+
+Count-Min Sketch
+^^^^^^^^^^^^^^^^
 .. automodule:: chronowords.utils.probabilistic_counter
    :members:
    :show-inheritance:
+
+PPMI computation (Cython)
+^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: chronowords.utils.count_skipgrams.PPMIComputer
+   :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,6 @@ extensions = [
     "sphinx.ext.githubpages",
     "sphinx_rtd_theme",
     "sphinx.ext.intersphinx",
-    "sphinx_autodoc_typehints",
 ]
 
 templates_path = ["_templates"]
@@ -37,6 +36,10 @@ napoleon_google_docstring = True
 napoleon_numpy_docstring = False
 napoleon_include_init_with_doc = True
 napoleon_include_private_with_doc = True
+# Render "Attributes:" sections as inline ``:ivar:`` fields rather than separate
+# ``py:attribute`` objects, so they don't collide with the attributes autodoc
+# already emits for dataclass fields (avoids "duplicate object description").
+napoleon_use_ivar = True
 
 # AutoDoc settings
 autodoc_default_options = {

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -1,26 +1,38 @@
 Examples
 ========
 
-Loading and Training a Model
---------------------------
+The worked example
+------------------
+
+The repository ships a complete, runnable notebook at
+``examples/presidential_speeches.ipynb``. It applies the full chronowords
+pipeline to U.S. presidential speeches grouped by quarter-century:
+
+#. load and group the speeches into time slices,
+#. build PPMI embeddings per slice with
+   :class:`~chronowords.algebra.svd.SVDAlgebra`,
+#. align the slices with
+   :class:`~chronowords.alignment.procrustes.ProcrustesAligner`,
+#. detect and visualise (with Altair) how individual words shifted, and
+#. model topics per slice with :class:`~chronowords.topics.nmf.TopicModel`.
+
+Clone the repository and open it with Jupyter to run it end-to-end.
+
+Short snippets
+--------------
+
+Train embeddings and find similar words:
 
 .. code-block:: python
 
-    from chronowords.algebra import SVDAlgebra
+   from chronowords.algebra import SVDAlgebra
 
-    # Initialize model
-    model = SVDAlgebra(n_components=300)
+   model = SVDAlgebra(n_components=300)
+   with open("corpus.txt", encoding="utf-8") as fh:
+       model.train(fh)
 
-    # Train on your corpus
-    with open('your_corpus.txt', 'r') as f:
-        model.train(f)
+   for hit in model.most_similar("computer", n=10):
+       print(f"{hit.word}: {hit.similarity:.3f}")
 
-Finding Similar Words
--------------------
-
-.. code-block:: python
-
-    # Find similar words
-    similar = model.most_similar('computer', n=10)
-    for word in similar:
-        print(f"{word.word}: {word.similarity:.3f}")
+For step-by-step walkthroughs see the :doc:`quickstart` (single corpus) and the
+:doc:`tutorial` (semantic shift across time slices).

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,7 +4,7 @@
    :width: 450px
 
 Welcome to chronowords's documentation!
-=====================================
+=======================================
 
 chronowords is a Python package for training small PPMI-based language models,
 making topic models via non-negative matrix factorization, and detecting semantic
@@ -14,13 +14,19 @@ Built and maintained by `Crow Intelligence <https://crowintelligence.org/>`_.
 
 Install from `PyPI <https://pypi.org/project/chronowords/>`_.
 
+New here? Start with the :doc:`quickstart`, then follow the :doc:`tutorial` to
+detect how a word's meaning shifts across time.
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
    installation
-   api
+   quickstart
+   tutorial
+   troubleshooting
    examples
+   api
 
 Indices and tables
 ==================

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,16 +1,37 @@
 Installation
-===========
+============
 
-Install using pip:
+Install the released package from PyPI:
 
 .. code-block:: bash
 
    pip install chronowords
 
-Or install from source:
+chronowords ships a compiled Cython extension, so a C/C++ compiler is required if
+no wheel is available for your platform. Python 3.10–3.12 is supported.
+
+Install from source
+-------------------
 
 .. code-block:: bash
 
-   git clone https://github.com/[your-username]/chronowords.git
+   git clone https://github.com/crow-intelligence/chronowords.git
    cd chronowords
    pip install -e .
+
+Development install with uv
+---------------------------
+
+The project is developed with `uv <https://docs.astral.sh/uv/>`_. To set up a
+full development environment (project, dev, and docs dependencies):
+
+.. code-block:: bash
+
+   uv sync --all-groups
+   uv run pytest          # run the test suite
+
+After editing the Cython source (``count_skipgrams.pyx``), rebuild the extension:
+
+.. code-block:: bash
+
+   uv sync --reinstall-package chronowords

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -1,0 +1,117 @@
+Quickstart
+==========
+
+This page walks through a complete, runnable example: building word embeddings
+from a corpus, finding similar words, and extracting topics. Every snippet below
+runs as-is on a clean install — copy them into a Python session in order.
+
+.. note::
+
+   The corpus here is deliberately tiny so the example runs instantly. Embedding
+   quality scales with corpus size, so the specific neighbours returned below are
+   illustrative, not meaningful. For a realistic, end-to-end study see
+   :doc:`tutorial` and the bundled
+   ``examples/presidential_speeches.ipynb`` notebook.
+
+Install
+-------
+
+.. code-block:: bash
+
+   pip install chronowords
+
+See :doc:`installation` for installing from source.
+
+Build embeddings from a corpus
+------------------------------
+
+:class:`~chronowords.algebra.svd.SVDAlgebra` trains PPMI-weighted word
+embeddings from any iterable of text lines. Internally it counts words and
+skip-grams with a Count-Min Sketch and factorises the PPMI matrix with truncated
+SVD.
+
+.. code-block:: python
+
+   from chronowords.algebra import SVDAlgebra
+
+   # Any iterable of strings works — a list, a generator, or an open file.
+   animal = [
+       "the cat chased the dog around the garden",
+       "the dog and the cat played near the rabbit",
+       "the rabbit and the dog ran past the cat",
+       "a cat watched the rabbit and the dog",
+   ]
+   royal = [
+       "the king ruled the kingdom beside the queen",
+       "the queen and the king visited the kingdom",
+       "the prince served the king and the queen",
+       "the kingdom welcomed the queen and the prince",
+   ]
+   corpus = (animal * 15) + (royal * 15)
+
+   model = SVDAlgebra(n_components=10, cms_width=10_000, cms_depth=4)
+   model.train(iter(corpus))
+
+   print(f"vocabulary size: {len(model.vocabulary)}")
+
+To train on a file, pass the file handle directly — each line is one document::
+
+   with open("corpus.txt", encoding="utf-8") as fh:
+       model.train(fh)
+
+Query the embeddings
+--------------------
+
+.. code-block:: python
+
+   # Nearest neighbours by cosine similarity.
+   for hit in model.most_similar("king", n=3):
+       print(f"{hit.word}: {hit.similarity:.3f}")
+
+   # Cosine distance between two words (None if either is unknown).
+   print(model.distance("cat", "dog"))
+
+   # The raw vector for a word (None if the word is not in the vocabulary).
+   vec = model.get_vector("queen")
+
+Unknown words never raise: :meth:`~chronowords.algebra.svd.SVDAlgebra.most_similar`
+returns an empty list and :meth:`~chronowords.algebra.svd.SVDAlgebra.distance`
+returns ``None``.
+
+Save and reload a model
+-----------------------
+
+.. code-block:: python
+
+   model.save_model("my_model")        # writes a directory of .npy / .pkl files
+
+   reloaded = SVDAlgebra()
+   reloaded.load_model("my_model")
+
+.. warning::
+
+   :meth:`~chronowords.algebra.svd.SVDAlgebra.load_model` unpickles the saved
+   vocabulary, which can execute arbitrary code. Only load model directories you
+   trust.
+
+Extract topics
+--------------
+
+:class:`~chronowords.topics.nmf.TopicModel` runs non-negative matrix
+factorisation over the PPMI matrix that ``train`` already computed
+(``model._ppmi_sparse``):
+
+.. code-block:: python
+
+   from chronowords.topics import TopicModel
+
+   topics = TopicModel(n_topics=2)
+   topics.fit(model._ppmi_sparse, model.vocabulary)
+   topics.print_topics(top_n=5)
+
+Next steps
+----------
+
+- :doc:`tutorial` — detect how a word's meaning shifts across time slices.
+- :doc:`troubleshooting` — common errors and how to fix them.
+- :doc:`api` — the full API reference.

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -1,0 +1,113 @@
+Troubleshooting
+===============
+
+Common errors and surprises, with the cause and the fix. These are drawn from
+the documented contracts of each method (see :doc:`api`).
+
+Training
+--------
+
+``ValueError: No words found meeting minimum frequency threshold``
+   :meth:`~chronowords.algebra.svd.SVDAlgebra.train` builds its vocabulary from
+   words above a 0.01% heavy-hitter threshold. This error means no word cleared
+   it — usually the corpus is empty, far too small, or was already consumed.
+
+   - Pass a fresh iterable. A generator or file handle is **consumed once**; if
+     you iterate it before calling ``train`` (or call ``train`` twice on the same
+     generator), the second pass sees nothing.
+   - Give it more data. The internal PPMI step also requires word and skip-gram
+     counts above 5, so very small corpora can train but yield a near-empty
+     vocabulary.
+
+``most_similar`` returns ``[]`` / ``distance`` and ``get_vector`` return ``None``
+   The model has not been trained, the word is not in the vocabulary, or the
+   word's vector has effectively zero norm. These cases are deliberately
+   non-raising and are indistinguishable from each other. Check
+   ``len(model.vocabulary)`` and ``word in model.vocabulary`` first.
+
+Results change between identical runs
+   If sparse SVD fails on a small or degenerate matrix,
+   :meth:`~chronowords.algebra.svd.SVDAlgebra.train` silently falls back to a
+   dense SVD **with a tiny amount of random noise added**, so embeddings can vary
+   slightly run-to-run. A larger corpus avoids the fallback path.
+
+Memory and accuracy (Count-Min Sketch)
+--------------------------------------
+
+The counter is a :class:`~chronowords.utils.probabilistic_counter.CountMinSketch`
+sized by ``cms_width`` and ``cms_depth``.
+
+- **Memory** is ``cms_width * cms_depth * 4`` bytes per sketch. The default
+  ``cms_width=1_000_000`` is ~20 MB per sketch (two are used during training).
+- **Accuracy**: counts are never underestimated but can be *over*-estimated on
+  hash collisions. If rare words leak into the vocabulary, increase ``cms_width``.
+  If memory is tight on a small corpus, lower it.
+
+Saving and loading
+------------------
+
+``FileNotFoundError`` when calling ``load_model``
+   The directory is missing ``embeddings.npy`` or ``vocabulary.pkl``. The most
+   common cause is calling
+   :meth:`~chronowords.algebra.svd.SVDAlgebra.save_model` **before** ``train``:
+   only attributes that are set are written, so an untrained model saves an empty
+   ``vocabulary.pkl`` and no embeddings. Train before saving.
+
+``ValueError: Directory not found``
+   :meth:`~chronowords.algebra.svd.SVDAlgebra.load_model` was given a path that
+   is not an existing directory. ``save_model`` writes a *directory* of files, not
+   a single file — pass that directory to ``load_model``.
+
+Loading executes code
+   Both ``SVDAlgebra.load_model`` and
+   :meth:`~chronowords.alignment.procrustes.ProcrustesAligner.load` unpickle
+   their input, which can run arbitrary code. Only load files you produced or
+   trust.
+
+Alignment
+---------
+
+``ValueError: No common words found for alignment`` / ``No valid anchor words found``
+   :meth:`~chronowords.alignment.procrustes.ProcrustesAligner.fit` could not
+   assemble anchors. Either the two vocabularies share too few words in the
+   frequency-rank window, or every candidate anchor was dropped for being missing
+   from one space or having a near-zero vector. Widen ``max_freq_rank``, or pass
+   an explicit ``anchor_words`` list of words you know are in both vocabularies.
+
+``ValueError: Aligner must be fit before transform``
+   Call :meth:`~chronowords.alignment.procrustes.ProcrustesAligner.fit` before
+   :meth:`~chronowords.alignment.procrustes.ProcrustesAligner.transform`.
+
+``get_word_similarity`` raises or returns ``nan``
+   It returns ``None`` if the word is missing from either vocabulary, but it does
+   **not** guard against zero-norm vectors (a zero vector yields ``nan`` and a
+   ``RuntimeWarning``) and it assumes the aligner has been fit. Make sure the word
+   is shared and the aligner is fitted.
+
+Topic modeling
+--------------
+
+``ValueError`` from ``TopicModel.fit``
+   Raised by scikit-learn's NMF when ``n_topics`` exceeds the matrix dimensions,
+   or if the matrix has negative entries. PPMI matrices are non-negative, so the
+   usual cause is too many topics for a small vocabulary — reduce ``n_topics``.
+
+``ValueError: Model must be fit before getting document topics``
+   Call :meth:`~chronowords.topics.nmf.TopicModel.fit` before
+   :meth:`~chronowords.topics.nmf.TopicModel.get_document_topics`.
+
+Empty or all-zero topics
+   On a tiny PPMI matrix, NMF can produce degenerate components whose weights sum
+   to zero; chronowords leaves those distributions unnormalised rather than
+   raising. Use a larger corpus for meaningful topics.
+
+Build / install
+---------------
+
+The Cython extension fails to import
+   ``chronowords.utils.count_skipgrams`` is a compiled Cython module. After
+   editing the ``.pyx`` source, rebuild it with::
+
+      uv sync --reinstall-package chronowords
+
+   A C/C++ compiler must be available on the build machine.

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -1,0 +1,158 @@
+Tutorial: Detecting Semantic Shift Over Time
+============================================
+
+The flagship workflow in chronowords is measuring how a word's meaning changes
+between time periods. The recipe is:
+
+#. Split your corpus into time slices (decades, reigns, regimes — whatever suits
+   the question).
+#. Train a separate :class:`~chronowords.algebra.svd.SVDAlgebra` embedding space
+   on each slice.
+#. Align the slices into a common space with
+   :class:`~chronowords.alignment.procrustes.ProcrustesAligner` (embedding spaces
+   from independent SVD runs are not directly comparable — axes are arbitrary).
+#. Score each shared word by how stable its aligned vector is across slices.
+#. Optionally, model topics per slice and align them to see how themes evolve.
+
+The bundled ``examples/presidential_speeches.ipynb`` notebook works this through
+end-to-end on U.S. presidential speeches grouped by quarter-century. The same
+recipe drove Crow Intelligence's study of gender bias in Hungarian media, where
+the question was how the words used around women shifted across decades.
+
+This tutorial uses two small synthetic slices so it runs quickly; swap in your
+own per-slice corpora to reproduce it for real.
+
+1. Train one embedding space per slice
+--------------------------------------
+
+Each slice is just an iterable of text lines. Train one model per slice with the
+**same** ``n_components`` so the spaces are the same dimensionality.
+
+.. code-block:: python
+
+   from chronowords.algebra import SVDAlgebra
+
+   def train_slice(lines):
+       model = SVDAlgebra(n_components=8, cms_width=10_000, cms_depth=4)
+       model.train(iter(lines))
+       return model
+
+   model_early = train_slice(corpus_1900s)   # your slice-1 lines
+   model_late = train_slice(corpus_1990s)    # your slice-2 lines
+
+For a real study, read each slice from disk::
+
+   def load_slice(path):
+       with open(path, encoding="utf-8") as fh:
+           return list(fh)
+
+2. Align the two spaces
+-----------------------
+
+:class:`~chronowords.alignment.procrustes.ProcrustesAligner` learns the
+orthogonal rotation that best maps the source space onto the target space, using
+words shared by both vocabularies as anchors. The frequency-rank window
+(``min_freq_rank`` / ``max_freq_rank``) selects stable, frequent anchors and
+skips the rare tail.
+
+.. code-block:: python
+
+   from chronowords.alignment import ProcrustesAligner
+
+   aligner = ProcrustesAligner(min_freq_rank=0, max_freq_rank=1000)
+   metrics = aligner.fit(
+       model_early.embeddings,
+       model_late.embeddings,
+       model_early.vocabulary,
+       model_late.vocabulary,
+   )
+   print(f"anchored on {metrics.num_aligned_words} words")
+   print(f"mean anchor cosine after alignment: {metrics.average_cosine_similarity:.3f}")
+
+A high ``average_cosine_similarity`` means the two spaces aligned well on the
+anchors; a low value means the slices are hard to compare (too few shared words,
+or genuinely divergent usage).
+
+.. note::
+
+   :meth:`~chronowords.alignment.procrustes.ProcrustesAligner.fit` raises
+   ``ValueError`` if there are no usable anchors. That usually means the two
+   slices share too few frequent words — widen ``max_freq_rank`` or check that
+   both vocabularies were built.
+
+3. Score how much each word shifted
+-----------------------------------
+
+:meth:`~chronowords.alignment.procrustes.ProcrustesAligner.get_word_similarity`
+returns the cosine similarity between a word's early and (aligned) late vectors.
+**High similarity means the word stayed stable; low similarity flags a semantic
+shift** — the words to investigate.
+
+.. code-block:: python
+
+   shared = [w for w in model_early.vocabulary if w in model_late.vocabulary]
+
+   shifts = []
+   for word in shared:
+       sim = aligner.get_word_similarity(
+           word, model_early.embeddings, model_late.embeddings
+       )
+       if sim is not None:
+           shifts.append((word, sim))
+
+   # Smallest similarity == largest shift.
+   shifts.sort(key=lambda pair: pair[1])
+   print("most shifted words:")
+   for word, sim in shifts[:10]:
+       print(f"  {word}: stability {sim:.3f}")
+
+4. Interpret a shift
+--------------------
+
+A low stability score tells you *that* a word moved, not *how*. Inspect each
+word's neighbours in both slices to read the change:
+
+.. code-block:: python
+
+   word = shifts[0][0]
+   print(f"{word!r} early neighbours:",
+         [h.word for h in model_early.most_similar(word, n=8)])
+   print(f"{word!r} late neighbours:",
+         [h.word for h in model_late.most_similar(word, n=8)])
+
+If the neighbour sets differ markedly, the word is being used in a new context —
+the semantic shift you set out to find.
+
+5. (Optional) Track topics across slices
+----------------------------------------
+
+To see how whole themes evolve rather than single words, fit a
+:class:`~chronowords.topics.nmf.TopicModel` per slice and align them. Topic
+alignment uses the Hungarian algorithm to pair each source topic with its closest
+target topic.
+
+.. code-block:: python
+
+   from chronowords.topics import TopicModel
+
+   topics_early = TopicModel(n_topics=10)
+   topics_early.fit(model_early._ppmi_sparse, model_early.vocabulary)
+
+   topics_late = TopicModel(n_topics=10)
+   topics_late.fit(model_late._ppmi_sparse, model_late.vocabulary)
+
+   for pair in topics_early.align_with(topics_late):
+       early_words = [w for w, _ in pair.source_topic.words[:5]]
+       late_words = [w for w, _ in pair.target_topic.words[:5]]
+       print(f"sim={pair.similarity:.2f}  {early_words}  ->  {late_words}")
+
+Pairs with low similarity are topics whose vocabulary changed most between
+slices.
+
+Where to go next
+----------------
+
+- ``examples/presidential_speeches.ipynb`` — the full pipeline with real data and
+  Altair visualisations.
+- :doc:`troubleshooting` — what the common errors mean.
+- :doc:`api` — full signatures and contracts for every method used above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dev = [
 docs = [
     "sphinx>=8.1.3",
     "sphinx-rtd-theme>=3.0.2",
-    "sphinx-autodoc-typehints>=3.0.1",
 ]
 
 [build-system]

--- a/src/chronowords/algebra/__init__.py
+++ b/src/chronowords/algebra/__init__.py
@@ -1,0 +1,6 @@
+from chronowords.algebra.svd import AnalogyResult
+from chronowords.algebra.svd import SVDAlgebra
+from chronowords.algebra.svd import WordSimilarity
+
+
+__all__ = ["AnalogyResult", "SVDAlgebra", "WordSimilarity"]

--- a/src/chronowords/algebra/svd.py
+++ b/src/chronowords/algebra/svd.py
@@ -25,13 +25,11 @@ logger = logging.getLogger(__name__)
 class WordSimilarity:
     """Container for word similarity results.
 
-    Fields:
-    ------
-        word: The similar word found
-        similarity: Cosine similarity score (between -1 and 1)
+    Attributes:
+        word: The similar word found.
+        similarity: Cosine similarity score, in the range [-1, 1].
 
-    Examples
-    --------
+    Examples:
         >>> sim = WordSimilarity("cat", 0.85)
         >>> sim.word
         'cat'
@@ -50,13 +48,15 @@ class WordSimilarity:
 class AnalogyResult:
     """Container for word analogy results.
 
-    Fields:
-    ------
-        words: List of words matching the analogy
-        similarities: Corresponding similarity scores for each word
+    Attributes:
+        words: List of words matching the analogy, ordered by descending
+            similarity.
+        similarities: Similarity score for each word. Parallel to ``words``;
+            the producer (:meth:`SVDAlgebra.analogy`) guarantees
+            ``len(words) == len(similarities)``, but this dataclass does not
+            enforce it.
 
-    Examples
-    --------
+    Examples:
         >>> result = AnalogyResult(["queen"], [0.76])
         >>> result.words
         ['queen']
@@ -74,11 +74,17 @@ class AnalogyResult:
 class SVDAlgebra:
     """Implements word vector algebra using SVD-based embeddings.
 
-    Uses Count-Min Sketch for memory-efficient counting and
-    Cython-optimized PPMI computation.
+    Builds PPMI-weighted word embeddings from a corpus via truncated SVD,
+    using a Count-Min Sketch for memory-efficient counting and a
+    Cython-optimized PPMI kernel.
 
-    Examples
-    --------
+    The model has a two-phase lifecycle: it is unusable until :meth:`train`
+    (or :meth:`load_model`) has populated ``vocabulary`` and ``embeddings``.
+    Query methods (:meth:`most_similar`, :meth:`distance`, :meth:`analogy`,
+    :meth:`get_vector`) return an empty result or ``None`` if called before
+    training rather than raising.
+
+    Examples:
         >>> model = SVDAlgebra(n_components=2)
         >>> model.n_components
         2
@@ -98,15 +104,26 @@ class SVDAlgebra:
         """Initialize SVDAlgebra.
 
         Args:
-        ----
-            n_components: Number of SVD components to keep
-            window_size: Window size for skipgrams
-            min_word_length: Minimum word length to consider
-            cms_width: Width of Count-Min Sketch tables
-            cms_depth: Number of hash functions for Count-Min Sketch
+            n_components: Number of SVD components (embedding dimensions) to
+                keep. During :meth:`train` this is clamped to
+                ``min(n_components, min(matrix.shape) - 1)`` and floored at 1,
+                so a value larger than the vocabulary yields fewer dimensions.
+            window_size: Skip-gram context window size.
+            min_word_length: Minimum word length to consider; shorter tokens
+                are dropped during training.
+            cms_width: Width of the Count-Min Sketch tables. Larger values
+                reduce count collisions at the cost of memory
+                (``cms_width * cms_depth * 4`` bytes per sketch).
+            cms_depth: Number of hash functions (rows) in the Count-Min Sketch.
+
+        Note:
+            Constructor arguments are stored without validation. The integer
+            arguments are assumed positive; non-positive values surface later
+            as errors from NumPy allocation (``cms_width``/``cms_depth``) or
+            from :func:`scipy.sparse.linalg.svds` (``n_components``) during
+            :meth:`train`, not here.
 
         Examples:
-        --------
             >>> model = SVDAlgebra(n_components=100)
             >>> model.n_components
             100
@@ -134,12 +151,39 @@ class SVDAlgebra:
     def train(self, corpus: Generator[str, None, None]) -> None:
         """Train the model on a text corpus.
 
+        Counts words and skip-grams with a Count-Min Sketch, builds the
+        vocabulary from words above a fixed frequency threshold, computes a
+        sparse PPMI matrix, and factorises it with truncated SVD. On success,
+        populates ``vocabulary``, ``embeddings``, ``_ppmi_sparse`` and
+        ``M_dense``.
+
         Args:
-        ----
-            corpus: Generator yielding text lines
+            corpus: Iterable of text lines (e.g. a generator). Each line is
+                split on whitespace; tokens shorter than ``min_word_length``
+                are discarded.
+
+        Raises:
+            ValueError: If no word clears the 0.01% heavy-hitter frequency
+                threshold, i.e. the corpus is empty or too small to build a
+                vocabulary (explicit check after counting).
+
+        Note:
+            Precondition: ``corpus`` is consumed exactly once; passing a
+            single-use iterator that has already been exhausted produces an
+            empty vocabulary and raises ``ValueError``.
+
+            Words are frequency-filtered by a Count-Min Sketch, which can
+            *overestimate* counts on hash collisions, so a rare word may
+            occasionally be admitted to the vocabulary.
+
+            Silenced failure: if sparse :func:`~scipy.sparse.linalg.svds`
+            raises (common for tiny or degenerate matrices), the error is
+            swallowed and the code falls back to a dense SVD of the matrix
+            *with Gaussian noise (sigma 1e-10) added*. The fallback path is
+            invisible to the caller and yields slightly different,
+            non-deterministic embeddings from the sparse path.
 
         Examples:
-        --------
             >>> model = SVDAlgebra(n_components=2)
             >>> text = ["the cat sat", "the dog ran"]
             >>> model.train(line for line in text)
@@ -225,12 +269,27 @@ class SVDAlgebra:
     def save_model(self, path: str | Path) -> None:
         """Save model embeddings and vocabulary to disk.
 
+        Writes up to four files into ``path``: ``ppmi.npz`` (sparse PPMI),
+        ``ppmi.npy`` (dense PPMI), ``embeddings.npy``, and ``vocabulary.pkl``.
+
         Args:
-        ----
-            path: Directory to save model files. Will be created if it doesn't exist
+            path: Directory to write model files to. Created (including
+                parents) if it does not exist.
+
+        Raises:
+            OSError: If ``path`` cannot be created or written (e.g. permission
+                denied, read-only filesystem) — propagated from ``mkdir`` /
+                ``np.save`` / ``open``.
+
+        Note:
+            Only attributes that are currently set are written: each of the
+            PPMI matrices and ``embeddings`` is saved only when not
+            ``None``. Calling this before :meth:`train` therefore writes a
+            ``vocabulary.pkl`` holding an empty list and no ``embeddings.npy``,
+            which makes the resulting directory unloadable by
+            :meth:`load_model`. No warning is emitted for a partial save.
 
         Examples:
-        --------
             >>> import tempfile
             >>> from pathlib import Path
             >>> model = SVDAlgebra(n_components=2)
@@ -259,16 +318,33 @@ class SVDAlgebra:
     def load_model(self, path: str | Path) -> None:
         """Load model embeddings and vocabulary from disk.
 
+        Restores ``embeddings``, ``vocabulary`` and (if present) ``M_dense``
+        from a directory previously written by :meth:`save_model`, and rebuilds
+        the vocabulary index.
+
         Args:
-        ----
-            path: Directory containing model files
+            path: Directory containing the saved model files.
 
         Raises:
-        ------
-            ValueError: If directory doesn't exist
+            ValueError: If ``path`` is not an existing directory (explicit
+                check).
+            FileNotFoundError: If ``embeddings.npy`` or ``vocabulary.pkl`` is
+                missing from ``path`` (implicit, from ``np.load`` / ``open``) —
+                e.g. when the directory came from a pre-training
+                :meth:`save_model`.
+            pickle.UnpicklingError: If ``vocabulary.pkl`` is corrupt.
+
+        Warning:
+            This method unpickles ``vocabulary.pkl``. Unpickling executes
+            arbitrary code embedded in the file, so only load model directories
+            from sources you trust.
+
+        Note:
+            ``ppmi.npy`` is restored only if present; ``ppmi.npz`` (the sparse
+            PPMI matrix) is not reloaded, so ``_ppmi_sparse`` stays ``None``
+            after loading.
 
         Examples:
-        --------
             >>> import tempfile
             >>> from pathlib import Path
             >>> model = SVDAlgebra(n_components=2)
@@ -299,15 +375,14 @@ class SVDAlgebra:
         """Get the embedding vector for a word.
 
         Args:
-        ----
-            word: Input word to look up
+            word: Input word to look up.
 
         Returns:
-        -------
-            Word vector if word is in vocabulary, None otherwise
+            The word's embedding vector, or ``None`` if the model is untrained
+            (``embeddings is None``) or ``word`` is not in the vocabulary. A
+            ``None`` return does not distinguish these two cases.
 
         Examples:
-        --------
             >>> model = SVDAlgebra(n_components=2)
             >>> model.vocabulary = ["cat", "dog"]
             >>> model._build_vocab_index()
@@ -329,19 +404,26 @@ class SVDAlgebra:
         return self.embeddings[idx]
 
     def most_similar(self, word: str, n: int = 10) -> list[WordSimilarity]:
-        """Find the n most similar words.
+        """Find the n most similar words by cosine similarity.
 
         Args:
-        ----
-            word: Query word
-            n: Number of similar words to return
+            word: Query word.
+            n: Maximum number of similar words to return.
 
         Returns:
-        -------
-            List of similar words with their similarity scores
+            Up to ``n`` :class:`WordSimilarity` results, sorted by descending
+            cosine similarity, excluding ``word`` itself. Empty if the model is
+            untrained, ``word`` is unknown, or ``word``'s vector has
+            effectively zero norm — these cases are indistinguishable from
+            "no similar words found".
+
+        Note:
+            Silenced numerical issues: vocabulary norms are floored at 1e-10 to
+            avoid division by zero, and any ``NaN`` similarity (from zero-norm
+            embeddings) is replaced with -1.0 and then filtered out, so
+            degenerate vectors are silently excluded rather than reported.
 
         Examples:
-        --------
             >>> model = SVDAlgebra(n_components=2)
             >>> model.vocabulary = ["cat", "dog", "fish"]
             >>> model._build_vocab_index()
@@ -386,16 +468,16 @@ class SVDAlgebra:
         """Calculate cosine distance between two words.
 
         Args:
-        ----
-            word1: First word
-            word2: Second word
+            word1: First word.
+            word2: Second word.
 
         Returns:
-        -------
-            Cosine distance between word vectors, or None if either word is unknown
+            Cosine distance in the range [0, 1], or ``None`` if either word is
+            unknown (or the model is untrained) or either vector has
+            effectively zero norm. A ``None`` return does not distinguish these
+            cases.
 
         Examples:
-        --------
             >>> model = SVDAlgebra(n_components=2)
             >>> model.vocabulary = ["cat", "dog"]
             >>> model._build_vocab_index()
@@ -425,19 +507,29 @@ class SVDAlgebra:
     ) -> AnalogyResult | None:
         """Solve word analogies (e.g., king - man + woman ≈ queen).
 
+        Computes the target vector ``negative - positive[0] + positive[1]``,
+        normalises it, and returns the vocabulary words closest to it.
+
         Args:
-        ----
-            positive: List of two positive words for the analogy
-            negative: The negative word
-            n: Number of results to return
+            positive: Exactly two positive words for the analogy.
+            negative: The negative word.
+            n: Maximum number of results to return.
 
         Returns:
-        -------
-            AnalogyResult containing similar words and their similarity scores,
-            or None if any input words are unknown
+            An :class:`AnalogyResult` (words sorted by descending similarity,
+            excluding the three input words and tokens shorter than
+            ``min_word_length``), or ``None``. Several distinct conditions all
+            collapse to ``None``: ``positive`` does not have exactly two
+            elements, the model is untrained, any input word is unknown, the
+            target vector is degenerate (near-zero norm), or no candidate
+            remains after filtering.
+
+        Note:
+            Silenced numerical issues: as in :meth:`most_similar`, vocabulary
+            norms are floored at 1e-10 and ``NaN`` similarities are mapped to
+            -1.0 and filtered out.
 
         Examples:
-        --------
             >>> model = SVDAlgebra(n_components=2)
             >>> model.vocabulary = ["king", "man", "woman", "queen"]
             >>> model._build_vocab_index()

--- a/src/chronowords/alignment/__init__.py
+++ b/src/chronowords/alignment/__init__.py
@@ -1,0 +1,5 @@
+from chronowords.alignment.procrustes import AlignmentMetrics
+from chronowords.alignment.procrustes import ProcrustesAligner
+
+
+__all__ = ["AlignmentMetrics", "ProcrustesAligner"]

--- a/src/chronowords/alignment/procrustes.py
+++ b/src/chronowords/alignment/procrustes.py
@@ -12,13 +12,14 @@ from scipy.linalg import orthogonal_procrustes
 class AlignmentMetrics:
     """Container for alignment quality metrics.
 
-    Fields:
-        average_cosine_similarity: Mean cosine similarity between aligned word pairs
-        num_aligned_words: Number of words successfully aligned
-        alignment_error: Frobenius norm of the difference between aligned matrices
+    Attributes:
+        average_cosine_similarity: Mean cosine similarity between aligned word
+            pairs, in the range [-1, 1] (near 1.0 for a good alignment).
+        num_aligned_words: Number of anchor words successfully aligned.
+        alignment_error: Frobenius norm of the residual between the rotated
+            source and target anchor matrices (>= 0).
 
-    Examples
-    --------
+    Examples:
         >>> metrics = AlignmentMetrics(0.85, 1000, 0.15)
         >>> metrics.average_cosine_similarity
         0.85
@@ -37,16 +38,19 @@ class AlignmentMetrics:
 class ProcrustesAligner:
     """Aligns word embeddings from different time periods using Procrustes analysis.
 
-    Finds optimal orthogonal transformation to align embeddings while preserving distances.
+    Finds the optimal orthogonal transformation that maps a source embedding
+    space onto a target space while preserving distances, using shared
+    vocabulary words as anchors. Must be :meth:`fit` before :meth:`transform`
+    or :meth:`get_word_similarity` can be used.
 
     Example:
-    -------
-        aligner = ProcrustesAligner()
-        metrics = aligner.fit(
-            embeddings_1800, embeddings_1850,
-            vocab_1800, vocab_1850
-        )
-        aligned_embeddings = aligner.transform(embeddings_1800)
+        >>> import numpy as np
+        >>> aligner = ProcrustesAligner()
+        >>> vocab = ["word1", "word2"]
+        >>> emb_1800 = np.array([[1.0, 0.0], [0.0, 1.0]])
+        >>> emb_1850 = np.array([[0.0, 1.0], [-1.0, 0.0]])
+        >>> _ = aligner.fit(emb_1800, emb_1850, vocab, vocab)
+        >>> aligned = aligner.transform(emb_1800)
 
     """
 
@@ -56,12 +60,19 @@ class ProcrustesAligner:
         """Initialize the aligner.
 
         Args:
-        ----
-            min_freq_rank: Minimum frequency rank for anchor words
-            max_freq_rank: Maximum frequency rank for anchor words
+            min_freq_rank: Lower bound (inclusive) of the frequency-rank slice
+                used to select anchor words. ``None`` means "from the start".
+            max_freq_rank: Upper bound (exclusive) of the frequency-rank slice.
+                ``None`` means "to the end".
+
+        Note:
+            Both arguments are used directly as list-slice bounds on the
+            vocabularies in :meth:`find_common_words`, which are assumed to be
+            ordered by descending frequency. They are not validated; a
+            ``min_freq_rank`` greater than ``max_freq_rank`` yields an empty
+            anchor set and causes :meth:`fit` to raise ``ValueError``.
 
         Examples:
-        --------
             >>> aligner = ProcrustesAligner(min_freq_rank=0, max_freq_rank=10)
             >>> aligner.min_freq_rank
             0
@@ -81,15 +92,21 @@ class ProcrustesAligner:
     ) -> list[str]:
         """Find common words between source and target vocabularies.
 
-        Uses frequency rank filtering (min_freq_rank to max_freq_rank) to select
-        stable anchor words for alignment.
+        Slices each vocabulary to the ``[min_freq_rank:max_freq_rank]`` rank
+        window and returns the intersection, providing stable anchor words for
+        alignment.
 
-        Returns
-        -------
-            List of common words sorted alphabetically
+        Args:
+            source_vocab: Source vocabulary, assumed ordered by descending
+                frequency.
+            target_vocab: Target vocabulary, assumed ordered by descending
+                frequency.
 
-        Examples
-        --------
+        Returns:
+            The common words within the rank window, sorted alphabetically.
+            Empty if the windows do not overlap.
+
+        Examples:
             >>> aligner = ProcrustesAligner(min_freq_rank=0, max_freq_rank=2)
             >>> source = ['the', 'in', 'a', 'rare']
             >>> target = ['in', 'the', 'new', 'a']
@@ -111,21 +128,42 @@ class ProcrustesAligner:
     ) -> AlignmentMetrics:
         """Learn the orthogonal transformation matrix using Procrustes analysis.
 
+        Selects anchor words, L2-normalises their source and target vectors,
+        and solves for the orthogonal matrix that best maps source anchors onto
+        target anchors. Sets ``orthogonal_matrix``, ``source_words``,
+        ``target_words`` and ``anchors``.
+
         Args:
-        ----
-            source_embeddings: Source space word embeddings
-            target_embeddings: Target space word embeddings
-            source_vocab: Vocabulary list for source embeddings
-            target_vocab: Vocabulary list for target embeddings
-            anchor_words: Optional list of specific words to use for alignment
-                         If None, uses common words filtered by frequency rank
+            source_embeddings: Source-space embeddings, row-indexed by
+                ``source_vocab``.
+            target_embeddings: Target-space embeddings, row-indexed by
+                ``target_vocab``.
+            source_vocab: Vocabulary list for ``source_embeddings``.
+            target_vocab: Vocabulary list for ``target_embeddings``.
+            anchor_words: Specific words to align on. If ``None``, common words
+                filtered by frequency rank (:meth:`find_common_words`) are used.
 
         Returns:
-        -------
-            AlignmentMetrics containing quality measures of the alignment
+            :class:`AlignmentMetrics` describing alignment quality.
+
+        Raises:
+            ValueError: If no anchor words are available (no common words, or
+                an empty ``anchor_words``), or if every candidate anchor is
+                dropped because it is missing from one vocabulary or has a
+                near-zero vector in either space.
+
+        Note:
+            Preconditions:
+                - Each embedding matrix must have a row for every entry in its
+                  vocabulary; a vocab/embedding length mismatch surfaces as an
+                  ``IndexError`` while gathering anchor vectors (not checked).
+                - The two embedding spaces must share dimensionality, otherwise
+                  :func:`scipy.linalg.orthogonal_procrustes` raises (not
+                  caught).
+                - Anchor words whose source or target vector is effectively
+                  zero are silently skipped.
 
         Examples:
-        --------
             >>> import numpy as np
             >>> aligner = ProcrustesAligner()
             >>> source_emb = np.array([[1., 0.], [0., 1.]])
@@ -213,15 +251,23 @@ class ProcrustesAligner:
         """Apply the learned transformation to align embeddings.
 
         Args:
-        ----
-            embeddings: Embeddings to transform
+            embeddings: Embeddings to transform, with the same dimensionality
+                as the space the aligner was fit on.
 
         Returns:
-        -------
-            Transformed embeddings in the target space
+            The embeddings rotated into the target space (``embeddings @
+            orthogonal_matrix``).
+
+        Raises:
+            ValueError: If the aligner has not been fit yet
+                (``orthogonal_matrix is None``).
+
+        Note:
+            The column count of ``embeddings`` must match ``orthogonal_matrix``;
+            a mismatch raises ``ValueError`` from the matrix multiply (not
+            checked explicitly).
 
         Examples:
-        --------
             >>> import numpy as np
             >>> aligner = ProcrustesAligner()
             >>> # No need to set source_words/target_words since we're just testing transform
@@ -241,20 +287,33 @@ class ProcrustesAligner:
     ):
         """Get similarity between word representations in source and target spaces.
 
+        Looks up ``word`` in both vocabularies, normalises its source and
+        target vectors, rotates the source vector into the target space, and
+        returns the cosine similarity.
+
         Args:
-        ----
-            word: Word to compare
-            source_emb: Source embeddings
-            target_emb: Target embeddings
+            word: Word to compare. Must be present in both ``source_words`` and
+                ``target_words`` (populated by :meth:`fit`).
+            source_emb: Source embeddings, row-indexed by ``source_words``.
+            target_emb: Target embeddings, row-indexed by ``target_words``.
 
         Returns:
-        -------
-            Cosine similarity [-1,1] between aligned vectors,
-            higher values indicate more similar usage between periods.
-            Returns None if word not found in either vocabulary.
+            Cosine similarity in [-1, 1] between the aligned source vector and
+            the target vector; higher means more similar usage across periods.
+            ``None`` if ``word`` is absent from either vocabulary.
+
+        Raises:
+            AttributeError: If the aligner has not been fit
+                (``orthogonal_matrix is None``) — surfaces from the matrix
+                multiply, which is *not* guarded here unlike :meth:`transform`.
+
+        Note:
+            The source/target vectors are divided by their L2 norm with no
+            zero-norm guard. A zero vector produces ``nan``/``inf`` entries and
+            a silent ``RuntimeWarning`` rather than ``None`` or an exception —
+            see the project pre-mortem.
 
         Examples:
-        --------
             >>> import numpy as np
             >>> aligner = ProcrustesAligner()
             >>> aligner.source_words = ['cat', 'dog']  # Set after initialization
@@ -284,7 +343,25 @@ class ProcrustesAligner:
         return float(np.dot(aligned_vec, target_vec))
 
     def save(self, path: Path) -> None:
-        """Save the aligner state."""
+        """Save the aligner state to disk via pickle.
+
+        Persists ``orthogonal_matrix``, ``source_words``, ``target_words``,
+        ``anchors`` and the frequency-rank bounds so a later :meth:`load` can
+        restore a fitted aligner.
+
+        Args:
+            path: File path to write the pickled state to.
+
+        Raises:
+            OSError: If ``path`` cannot be opened for writing (propagated from
+                ``open``).
+
+        Note:
+            Saving an unfitted aligner is allowed and writes
+            ``orthogonal_matrix=None``; reloading it yields an aligner that
+            still needs :meth:`fit`.
+
+        """
         data = {
             "orthogonal_matrix": self.orthogonal_matrix,
             "source_words": self.source_words,
@@ -297,7 +374,24 @@ class ProcrustesAligner:
             pickle.dump(data, f)
 
     def load(self, path: Path) -> None:
-        """Load the aligner state."""
+        """Load aligner state from a pickle written by :meth:`save`.
+
+        Overwrites ``orthogonal_matrix``, ``source_words``, ``target_words``,
+        ``anchors`` and the frequency-rank bounds with the saved values.
+
+        Args:
+            path: File path to read the pickled state from.
+
+        Raises:
+            FileNotFoundError: If ``path`` does not exist.
+            KeyError: If the pickle is missing an expected key (e.g. it was not
+                written by :meth:`save`).
+
+        Warning:
+            This method unpickles ``path``. Unpickling executes arbitrary code
+            embedded in the file, so only load aligner files you trust.
+
+        """
         with Path.open(path, "rb") as f:
             data = pickle.load(f)
         self.orthogonal_matrix = data["orthogonal_matrix"]

--- a/src/chronowords/topics/__init__.py
+++ b/src/chronowords/topics/__init__.py
@@ -1,0 +1,6 @@
+from chronowords.topics.nmf import AlignedTopic
+from chronowords.topics.nmf import Topic
+from chronowords.topics.nmf import TopicModel
+
+
+__all__ = ["AlignedTopic", "Topic", "TopicModel"]

--- a/src/chronowords/topics/nmf.py
+++ b/src/chronowords/topics/nmf.py
@@ -13,13 +13,16 @@ from sklearn.decomposition import NMF
 class Topic:
     """Container for topic information.
 
-    Fields:
-        id: Unique topic identifier
-        words: List of (word, weight) pairs for top words
-        distribution: Full probability distribution over vocabulary
+    Attributes:
+        id: Unique topic identifier.
+        words: List of ``(word, weight)`` pairs for the top words, ordered by
+            descending weight.
+        distribution: Full weight distribution over the vocabulary. Produced by
+            :meth:`TopicModel.fit` as a non-negative vector that sums to 1
+            (unless the raw NMF weights summed to 0, in which case it is left
+            unnormalised). The dataclass does not enforce this.
 
-    Examples
-    --------
+    Examples:
         >>> import numpy as np
         >>> dist = np.array([0.5, 0.3, 0.2])
         >>> topic = Topic(1, [('cat', 0.5), ('dog', 0.3)], dist)
@@ -41,13 +44,14 @@ class Topic:
 class AlignedTopic:
     """Container for aligned topic pairs.
 
-    Fields:
-        source_topic: Topic from source time period
-        target_topic: Topic from target time period
-        similarity: Cosine similarity between topics
+    Attributes:
+        source_topic: Topic from the source time period.
+        target_topic: Topic from the target time period.
+        similarity: Cosine similarity between the two topic distributions, in
+            the range [-1, 1] (typically [0, 1] for non-negative
+            distributions).
 
-    Examples
-    --------
+    Examples:
         >>> import numpy as np
         >>> dist = np.array([0.5, 0.3, 0.2])
         >>> topic1 = Topic(1, [('cat', 0.5)], dist)
@@ -82,13 +86,19 @@ class TopicModel:
         """Initialize topic model.
 
         Args:
-        ----
-            n_topics: Number of topics to extract
-            max_iter: Maximum number of iterations for NMF
-            min_similarity: Minimum similarity for topic alignment
+            n_topics: Number of topics (NMF components) to extract. Must not
+                exceed the smaller dimension of the matrix passed to
+                :meth:`fit`, or sklearn's NMF raises.
+            max_iter: Maximum number of NMF iterations.
+            min_similarity: Minimum cosine similarity for a pair to be kept by
+                :meth:`align_with`.
+
+        Note:
+            Arguments are passed to :class:`sklearn.decomposition.NMF`
+            unvalidated; invalid values (e.g. ``n_topics <= 0``) surface as
+            errors from sklearn during :meth:`fit`, not here.
 
         Examples:
-        --------
             >>> model = TopicModel(n_topics=5, max_iter=100)
             >>> model.n_topics
             5
@@ -115,14 +125,31 @@ class TopicModel:
     ) -> None:
         """Fit topic model to PPMI matrix.
 
+        Runs NMF on ``ppmi_matrix``, then builds one :class:`Topic` per
+        component with a normalised weight distribution and its top words.
+        Populates ``vocabulary``, ``topic_word_matrix`` and ``topics``.
+
         Args:
-        ----
-            ppmi_matrix: Sparse PPMI matrix from word embeddings
-            vocabulary: List of words corresponding to matrix columns
-            top_n_words: Number of top words to store per topic
+            ppmi_matrix: Non-negative (sparse) PPMI matrix. Its number of
+                columns must equal ``len(vocabulary)``.
+            vocabulary: Words corresponding to the matrix columns.
+            top_n_words: Number of top words to store per topic.
+
+        Raises:
+            ValueError: From :class:`sklearn.decomposition.NMF` if
+                ``n_topics`` exceeds the matrix dimensions or the matrix
+                contains negative entries (PPMI is non-negative, so the latter
+                normally cannot happen).
+            IndexError: If ``len(vocabulary)`` is smaller than the number of
+                matrix columns (implicit, when indexing ``vocabulary[idx]`` for
+                top words). Not checked explicitly.
+
+        Note:
+            For any topic whose raw NMF weights sum to 0, the distribution is
+            left unnormalised (it stays all-zero) rather than raising — that
+            topic's ``distribution`` will not sum to 1.
 
         Examples:
-        --------
             >>> import numpy as np
             >>> from scipy.sparse import csr_matrix
             >>> model = TopicModel(n_topics=2)
@@ -175,16 +202,25 @@ class TopicModel:
         """Get topic distribution for a document vector.
 
         Args:
-        ----
-            doc_vector: Document vector in vocabulary space
-            threshold: Minimum topic proportion to include
+            doc_vector: Document vector in vocabulary space. Its length must
+                match the feature dimension the model was fit on.
+            threshold: Minimum topic proportion to include (strict ``>``).
 
         Returns:
-        -------
-            List of (topic_id, weight) pairs above threshold, sorted by weight
+            ``(topic_id, weight)`` pairs whose weight strictly exceeds
+            ``threshold``, sorted by descending weight. May be empty.
+
+        Raises:
+            ValueError: If the model has not been fit
+                (``topic_word_matrix is None``) — explicit check.
+
+        Note:
+            If the projected topic weights sum to 0, they are returned
+            unnormalised rather than raising. ``doc_vector`` of the wrong
+            length raises from :meth:`sklearn.decomposition.NMF.transform`
+            (not checked here).
 
         Examples:
-        --------
             >>> import numpy as np
             >>> from scipy.sparse import csr_matrix
             >>> model = TopicModel(n_topics=2)
@@ -223,19 +259,26 @@ class TopicModel:
     ) -> tuple[np.ndarray, np.ndarray]:
         """Align two topic distributions to use the same vocabulary space.
 
+        Projects both topics onto the sorted union of ``vocab1`` and ``vocab2``
+        (missing words get weight 0), then renormalises each to sum to 1.
+
         Args:
-        ----
-            topic1: First topic
-            topic2: Second topic
-            vocab1: Vocabulary for first topic
-            vocab2: Vocabulary for second topic
+            topic1: First topic. ``topic1.distribution`` must be indexable by
+                ``vocab1`` positions.
+            topic2: Second topic. ``topic2.distribution`` must be indexable by
+                ``vocab2`` positions.
+            vocab1: Vocabulary for ``topic1``.
+            vocab2: Vocabulary for ``topic2``.
 
         Returns:
-        -------
-            Tuple of aligned distributions
+            Two distributions of equal length (the size of the unified
+            vocabulary), each renormalised to sum to 1 unless it was all-zero.
+
+        Note:
+            A distribution that is shorter than its vocabulary raises
+            ``IndexError`` while gathering values (not checked).
 
         Examples:
-        --------
             >>> import numpy as np
             >>> model = TopicModel()
             >>> dist1 = np.array([0.6, 0.4])
@@ -280,17 +323,24 @@ class TopicModel:
     def _compute_topic_similarity(self, topic1: Topic, topic2: Topic) -> float:
         """Compute cosine similarity between topic distributions.
 
+        Both topics are aligned against ``self.vocabulary`` (so this assumes
+        both come from this model's vocabulary), then compared.
+
         Args:
-        ----
-            topic1: First topic
-            topic2: Second topic
+            topic1: First topic.
+            topic2: Second topic.
 
         Returns:
-        -------
-            Cosine similarity between the topics
+            Cosine similarity in [-1, 1]. Returns 0.0 if either aligned
+            distribution is all-zero, if the result is ``NaN``, or if any
+            exception is raised during the computation.
+
+        Note:
+            The computation is wrapped in a broad ``except Exception`` that
+            maps any failure to 0.0, so a genuine error is indistinguishable
+            from a true zero similarity. See the project pre-mortem.
 
         Examples:
-        --------
             >>> import numpy as np
             >>> model = TopicModel()
             >>> dist1 = np.array([1, 0])
@@ -322,22 +372,32 @@ class TopicModel:
             return 0.0
 
     def align_with(self, other: "TopicModel") -> list[AlignedTopic]:
-        """Align topics with another model using Hungarian algorithm.
+        """Align topics with another model using the Hungarian algorithm.
+
+        Builds a topic-by-topic cosine-distance cost matrix over the unified
+        vocabulary, finds the optimal one-to-one matching with
+        :func:`scipy.optimize.linear_sum_assignment`, and keeps pairs whose
+        similarity is at least ``min_similarity``.
 
         Args:
-        ----
-            other: Another fitted TopicModel
+            other: Another fitted :class:`TopicModel`.
 
         Returns:
-        -------
-            List of aligned topic pairs sorted by similarity
+            Matched :class:`AlignedTopic` pairs with similarity >=
+            ``min_similarity``, sorted by descending similarity. May be empty
+            if no pair clears the threshold.
 
         Raises:
-        ------
-            ValueError: If either model is not fitted
+            ValueError: If either model has not been fit (``self.topics`` or
+                ``other.topics`` is empty).
+
+        Note:
+            Each topic's ``distribution`` is assumed indexable by its model's
+            ``vocabulary``. Unlike :meth:`_compute_topic_similarity`, the
+            cosine call here is not guarded, so an all-zero distribution can
+            yield a ``NaN`` cost entry.
 
         Examples:
-        --------
             >>> import numpy as np
             >>> from scipy.sparse import csr_matrix
             >>> model1 = TopicModel(n_topics=2)
@@ -406,11 +466,13 @@ class TopicModel:
         """Print top words for each topic.
 
         Args:
-        ----
-            top_n: Number of top words to print per topic
+            top_n: Maximum number of top words to print per topic.
+
+        Note:
+            Prints to stdout and returns ``None``. If the model has not been
+            fit, prints an advisory message instead of raising.
 
         Examples:
-        --------
             >>> from scipy.sparse import csr_matrix
             >>> model = TopicModel(n_topics=1)
             >>> ppmi = csr_matrix([[1, 0], [0, 1]])

--- a/src/chronowords/utils/__init__.py
+++ b/src/chronowords/utils/__init__.py
@@ -1,1 +1,4 @@
-# utils
+from chronowords.utils.probabilistic_counter import CountMinSketch
+
+
+__all__ = ["CountMinSketch"]

--- a/src/chronowords/utils/count_skipgrams.pyx
+++ b/src/chronowords/utils/count_skipgrams.pyx
@@ -24,8 +24,16 @@ ctypedef np.int32_t DTYPE_t
 cdef class PPMIComputer:
     """Encapsulates PPMI computation state and methods.
 
-    This class computes PPMI (Positive Pointwise Mutual Information) matrices
-    using Count-Min Sketch for memory efficiency.
+    Computes a Positive Pointwise Mutual Information (PPMI) matrix directly
+    from Count-Min Sketch count tables, avoiding materialisation of a dense
+    co-occurrence matrix. Word and skip-gram counts are read back from the
+    sketch via the same hashing scheme used to populate it.
+
+    The PPMI for a word pair ``(a, b)`` is ``max(0, log(P(a,b) / (P(a)^alpha *
+    P(b))) - log(shift))``, where probabilities come from the sketch counts.
+    Both words must have a sketch count strictly greater than 5, and only
+    strictly-positive PMI values are retained, so the result is sparse and
+    non-negative.
     """
     cdef:
         public np.ndarray skipgram_counts
@@ -50,7 +58,44 @@ cdef class PPMIComputer:
                  double word_total,
                  double shift=1.0,
                  double alpha=0.75):
-        """Initialize the PPMI computer with Count-Min Sketch data."""
+        """Initialize the PPMI computer with Count-Min Sketch data.
+
+        Args:
+            skipgram_counts: Count-Min Sketch table for skip-gram pairs, a 2-D
+                int32 array of shape ``(depth, width)`` (from
+                ``CountMinSketch.arrays``).
+            word_counts: Count-Min Sketch table for single words, same
+                ``(depth, width)`` int32 shape and seeds as ``skipgram_counts``.
+            vocabulary: Words to compute PPMI over; defines the matrix axes.
+            seeds: One mmh3 hash seed per sketch row (length ``depth``).
+                Defaults to ``[1, 2, 3]`` if ``None``.
+            width: Sketch table width; used as the modulus for hash indices.
+                Must match the tables' second dimension.
+            skip_total: Total number of skip-gram observations (denominator for
+                joint probabilities). Must be > 0.
+            word_total: Total number of word observations (denominator for
+                marginal probabilities). Must be > 0.
+            shift: PMI shift; ``log(shift)`` is subtracted from each PMI (an
+                a shifted-PPMI / negative-sampling analogue). Must be > 0.
+            alpha: Context-distribution smoothing exponent applied to the focus
+                word's marginal (typically 0.75).
+
+        Raises:
+            ValueError: If any element of ``seeds`` is not an ``int``.
+
+        Note:
+            Preconditions not enforced:
+                - Array shapes, dtypes, and ``width`` consistency are assumed,
+                  not checked; a mismatch produces wrong counts or an
+                  out-of-bounds access (bounds checking is disabled).
+                - ``word_total``/``skip_total`` must be positive; a value of 0
+                  yields ``inf``/``nan`` PPMI entries. ``shift`` must be
+                  positive, otherwise ``log(shift)`` is ``nan``/``-inf``.
+                - The smoothing exponent ``alpha`` is applied only to the focus
+                  word's probability (``pa``), not the context word's (``pb``);
+                  this asymmetry is intentional but easy to misread — see the
+                  project pre-mortem.
+        """
         self.skipgram_counts = skipgram_counts
         self.word_counts = word_counts
         self.vocabulary = vocabulary
@@ -70,7 +115,12 @@ cdef class PPMIComputer:
         self.word_probs = vector[double]()
 
     cdef int _get_min_count(self, bytes word_bytes) except -1:
-        """Get minimum count from Count-Min Sketch arrays."""
+        """Return the Count-Min Sketch estimate for ``word_bytes``.
+
+        Hashes the key with each row seed and returns the minimum count across
+        rows — the standard CMS point query, which never underestimates the
+        true count.
+        """
         cdef:
             int i, idx, min_count
             int depth = self.skipgram_counts.shape[0]
@@ -86,7 +136,13 @@ cdef class PPMIComputer:
         return min_count
 
     cdef void _precompute_word_probabilities(self):
-        """Pre-compute word probabilities for efficiency."""
+        """Pre-compute per-word marginal probabilities into ``word_probs``.
+
+        For each vocabulary word, queries the sketch and stores
+        ``count / word_total`` if the count is strictly greater than 5,
+        otherwise 0.0. A stored probability of 0.0 marks the word as too rare
+        and excludes it from all PPMI pairs.
+        """
         cdef:
             int i, count
             int n = len(self.vocabulary)
@@ -104,7 +160,24 @@ cdef class PPMIComputer:
                 self.word_probs[i] = 0.0
 
     def compute_ppmi_batch(self, int start_idx, int end_idx):
-        """Compute PPMI for a batch of words."""
+        """Compute PPMI entries for focus words in ``[start_idx, end_idx)``.
+
+        Lazily precomputes word probabilities on the first call. For each focus
+        word in the half-open range (clamped to the vocabulary size) it scans
+        every context word and emits a PPMI entry when both words clear the
+        count-5 threshold and the resulting PMI is strictly positive.
+
+        Args:
+            start_idx: First focus-word index (inclusive).
+            end_idx: One past the last focus-word index (exclusive); clamped to
+                ``len(vocabulary)``.
+
+        Returns:
+            A tuple ``(data, row_indices, col_indices)`` of NumPy arrays giving
+            the COO components of the PPMI entries for this batch. All ``data``
+            values are strictly positive. The arrays are empty when no pair in
+            the batch qualifies.
+        """
         cdef:
             int i, j, pair_count
             double pa, pb, pab, pmi
@@ -148,7 +221,20 @@ cdef class PPMIComputer:
         return np.array(data), np.array(row_indices), np.array(col_indices)
 
     def compute_ppmi_matrix_with_sketch(self, int batch_size=1024):
-        """Compute complete PPMI matrix using batched processing."""
+        """Compute the complete PPMI matrix using batched processing.
+
+        Calls :meth:`compute_ppmi_batch` over successive focus-word batches and
+        assembles the results into a single sparse matrix.
+
+        Args:
+            batch_size: Number of focus words processed per batch. Affects
+                memory/throughput only, not the result.
+
+        Returns:
+            An ``(n, n)`` :class:`scipy.sparse.csr_matrix` (``n`` =
+            vocabulary size) of non-negative PPMI values. Returns an empty
+            ``(n, n)`` matrix when no pair qualifies.
+        """
         cdef:
             int n = len(self.vocabulary)
             list all_data = []

--- a/src/chronowords/utils/probabilistic_counter.py
+++ b/src/chronowords/utils/probabilistic_counter.py
@@ -5,12 +5,15 @@ import numpy as np
 class CountMinSketch:
     """Count-Min Sketch implementation for memory-efficient counting.
 
-    Uses multiple hash functions to approximate frequencies with bounded error.
-    Memory usage: width * depth * 4 bytes
-    Error bound: ≈ 2/width with probability 1 - 1/2^depth
+    Uses ``depth`` hash functions over ``width`` counters each to approximate
+    item frequencies in fixed memory. Queries never underestimate the true
+    count; they may overestimate it due to hash collisions.
 
-    Examples
-    --------
+    - Memory usage: ``width * depth * 4`` bytes (int32 counters).
+    - Error bound: an overestimate of about ``2 / width`` of the total count,
+      with probability at least ``1 - 1 / 2**depth``.
+
+    Examples:
         >>> cms = CountMinSketch(width=1000, depth=5, seed=42)
         >>> cms.width
         1000
@@ -29,11 +32,20 @@ class CountMinSketch:
         """Initialize Count-Min Sketch.
 
         Args:
-        ----
-            width: Number of counters per hash function (controls accuracy)
-            depth: Number of hash functions (controls probability bound)
-            seed: Random seed for hash function initialization
-            track_keys: Whether to track observed keys (disable for memory savings)
+            width: Number of counters per hash function (controls accuracy).
+                Must be a positive integer.
+            depth: Number of hash functions / rows (controls the probability
+                bound). Must be a positive integer.
+            seed: Seed for deriving the per-row hash seeds; fixes the sketch's
+                hashing so that two sketches with the same ``seed`` (and
+                ``width``/``depth``) are merge-compatible.
+            track_keys: Whether to record observed keys so
+                :meth:`get_heavy_hitters` can enumerate them. Disable to save
+                memory; :meth:`get_heavy_hitters` then raises.
+
+        Note:
+            Arguments are not validated. ``width``/``depth`` must be positive
+            or the underlying ``numpy.zeros((depth, width))`` allocation fails.
 
         """
         self.width = width
@@ -61,12 +73,12 @@ class CountMinSketch:
         """Update count for a key.
 
         Args:
-        ----
-            key: Item to count (string or bytes)
-            count: Amount to increment (default: 1)
+            key: Item to count. ``str`` keys are UTF-8 encoded; ``bytes`` keys
+                are used as-is (and decoded for key tracking).
+            count: Amount to increment by (default 1). Added to ``total`` and
+                to each row counter as-is; no positivity check is performed.
 
         Examples:
-        --------
             >>> cms = CountMinSketch(width=1000, depth=5, seed=42)
             >>> cms.update("apple")
             >>> cms.update("apple")
@@ -94,10 +106,18 @@ class CountMinSketch:
         self.counts[self._row_indices, indices] += count
 
     def query(self, key: str | bytes) -> int:
-        """Query count for a key.
+        """Query the estimated count for a key.
 
-        Examples
-        --------
+        Args:
+            key: Item to look up (``str`` is UTF-8 encoded; ``bytes`` used
+                as-is).
+
+        Returns:
+            The minimum counter across rows, which is the Count-Min Sketch
+            estimate. This never underestimates the true count and returns 0
+            for an unseen key (barring collisions).
+
+        Examples:
             >>> cms = CountMinSketch(width=1000, depth=5, seed=42)
             >>> cms.update("rare_word")
             >>> cms.query("rare_word")
@@ -113,22 +133,25 @@ class CountMinSketch:
         return int(np.min(self.counts[self._row_indices, indices]))
 
     def get_heavy_hitters(self, threshold: float) -> list[tuple[str, int]]:
-        """Get items that appear more than threshold * total times.
+        """Get items that appear more than ``threshold * total`` times.
 
         Args:
-        ----
-            threshold: Minimum frequency as fraction of total counts
+            threshold: Minimum frequency as a fraction of the total count,
+                normally in (0, 1). Not validated; the comparison threshold is
+                ``int(total * threshold)`` (truncated toward zero).
 
         Returns:
-        -------
-            List of (item, count) pairs sorted by count descending
+            ``(item, count)`` pairs whose estimated count is strictly greater
+            than ``int(total * threshold)``, sorted by descending count.
+            Counts are CMS estimates, so a returned count may overestimate the
+            true value (and a borderline item may be a false positive), but no
+            genuine heavy hitter is missed.
 
         Raises:
-        ------
-            RuntimeError: If track_keys was disabled
+            RuntimeError: If the sketch was created with ``track_keys=False``,
+                since observed keys are then not retained.
 
         Examples:
-        --------
             >>> cms = CountMinSketch(width=1000, depth=5, seed=42)
             >>> # Add a frequent word
             >>> for _ in range(100):
@@ -157,10 +180,22 @@ class CountMinSketch:
         return sorted(candidates.items(), key=lambda x: x[1], reverse=True)
 
     def merge(self, other: "CountMinSketch") -> None:
-        """Merge another sketch into this one.
+        """Merge another sketch into this one, in place.
 
-        Examples
-        --------
+        Adds ``other``'s counters and total into ``self`` and unions the
+        tracked keys. Because both sketches share hashing parameters, the
+        result is identical to a single sketch built from the concatenation of
+        the two input streams.
+
+        Args:
+            other: Another sketch with the same ``width``, ``depth`` and
+                derived ``seeds`` as ``self``.
+
+        Raises:
+            ValueError: If ``other`` is not merge-compatible (differing
+                ``width``, ``depth`` or ``seeds``).
+
+        Examples:
             >>> cms1 = CountMinSketch(width=1000, depth=5, seed=42)
             >>> cms2 = CountMinSketch(width=1000, depth=5, seed=42)
             >>> cms1.update("word", count=3)
@@ -190,18 +225,22 @@ class CountMinSketch:
         self._observed_keys.update(other._observed_keys)
 
     def estimate_error(self, confidence: float = 0.95) -> float:
-        """Estimate maximum counting error.
+        """Estimate the maximum counting error.
 
         Args:
-        ----
-            confidence: Confidence level for the error bound
+            confidence: Intended confidence level for the bound.
 
         Returns:
-        -------
-            Maximum expected counting error at given confidence level
+            The expected maximum overestimate, ``(2 / width) * total``.
+
+        Note:
+            The ``confidence`` argument currently has **no effect** on the
+            returned value: an internal ``delta`` term is computed from
+            ``confidence`` but discarded before the return. The result depends
+            only on ``width`` and ``total``. Flagged in the project pre-mortem;
+            kept as-is to preserve behaviour.
 
         Examples:
-        --------
             >>> cms = CountMinSketch(width=1000, depth=5, seed=42)
             >>> for _ in range(1000):
             ...     cms.update("word")
@@ -222,10 +261,15 @@ class CountMinSketch:
 
     @property
     def arrays(self) -> tuple[np.ndarray, list[int], int]:
-        """Get raw arrays and parameters for Cython code.
+        """Get raw arrays and parameters for the Cython PPMI kernel.
 
-        Examples
-        --------
+        Returns:
+            A tuple ``(counts, seeds, width)`` exposing the internal count
+            table (shape ``(depth, width)``), the per-row hash seeds, and the
+            table width — the inputs :class:`~chronowords.utils.count_skipgrams.PPMIComputer`
+            needs to re-query the sketch.
+
+        Examples:
             >>> cms = CountMinSketch(width=3, depth=2, seed=42)
             >>> counts, seeds, width = cms.arrays
             >>> counts.shape

--- a/uv.lock
+++ b/uv.lock
@@ -364,7 +364,7 @@ wheels = [
 
 [[package]]
 name = "chronowords"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "cython" },
@@ -400,9 +400,6 @@ docs = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sphinx-autodoc-typehints", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx-autodoc-typehints", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "sphinx-autodoc-typehints", version = "3.9.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-rtd-theme" },
 ]
 
@@ -434,7 +431,6 @@ dev = [
 ]
 docs = [
     { name = "sphinx", specifier = ">=8.1.3" },
-    { name = "sphinx-autodoc-typehints", specifier = ">=3.0.1" },
     { name = "sphinx-rtd-theme", specifier = ">=3.0.2" },
 ]
 
@@ -2782,55 +2778,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl", hash = "sha256:c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978", size = 3921742, upload-time = "2025-12-31T15:09:25.561Z" },
-]
-
-[[package]]
-name = "sphinx-autodoc-typehints"
-version = "3.0.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11'",
-]
-dependencies = [
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/26/f0/43c6a5ff3e7b08a8c3b32f81b859f1b518ccc31e45f22e2b41ced38be7b9/sphinx_autodoc_typehints-3.0.1.tar.gz", hash = "sha256:b9b40dd15dee54f6f810c924f863f9cf1c54f9f3265c495140ea01be7f44fa55", size = 36282, upload-time = "2025-01-16T18:25:30.958Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/dc/dc46c5c7c566b7ec5e8f860f9c89533bf03c0e6aadc96fb9b337867e4460/sphinx_autodoc_typehints-3.0.1-py3-none-any.whl", hash = "sha256:4b64b676a14b5b79cefb6628a6dc8070e320d4963e8ff640a2f3e9390ae9045a", size = 20245, upload-time = "2025-01-16T18:25:27.394Z" },
-]
-
-[[package]]
-name = "sphinx-autodoc-typehints"
-version = "3.6.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-]
-dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/f6/bdd93582b2aaad2cfe9eb5695a44883c8bc44572dd3c351a947acbb13789/sphinx_autodoc_typehints-3.6.1.tar.gz", hash = "sha256:fa0b686ae1b85965116c88260e5e4b82faec3687c2e94d6a10f9b36c3743e2fe", size = 37563, upload-time = "2026-01-02T15:23:46.543Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/6a/c0360b115c81d449b3b73bf74b64ca773464d5c7b1b77bda87c5e874853b/sphinx_autodoc_typehints-3.6.1-py3-none-any.whl", hash = "sha256:dd818ba31d4c97f219a8c0fcacef280424f84a3589cedcb73003ad99c7da41ca", size = 20869, upload-time = "2026-01-02T15:23:45.194Z" },
-]
-
-[[package]]
-name = "sphinx-autodoc-typehints"
-version = "3.9.8"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-]
-dependencies = [
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/74/4d/02216afa475c838c123b41f30e3a2875ad27c14fae3f5bbed4ba4e7fd894/sphinx_autodoc_typehints-3.9.8.tar.gz", hash = "sha256:1e36b31ee593b7e838988045918b7fa965f5062abbd6800af96d5e2c3f17130e", size = 68763, upload-time = "2026-03-09T15:40:01.02Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/6c/f275f59095b2fec6627c3ce2caba4e18f55a3925718cf0547cde04821a37/sphinx_autodoc_typehints-3.9.8-py3-none-any.whl", hash = "sha256:df123ec82479934fed27e31d4ccdcf382901c5d9481450fc224054496e574466", size = 36685, upload-time = "2026-03-09T15:39:59.567Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this does

Rebuilds the documentation users complained about, and replaces every public-API docstring with an **honest contract** (preconditions, what's raised, what's silently swallowed).

### Documentation
- **Contract docstrings** across `svd.py`, `procrustes.py`, `nmf.py`, `probabilistic_counter.py`, and the Cython `PPMIComputer` (previously near-undocumented). Each method now documents preconditions, explicit vs. implicit exceptions, and silent fallbacks (e.g. `train`'s dense-SVD-with-noise fallback, `most_similar`'s NaN→-1 handling, `_compute_topic_similarity`'s broad `except`).
- **Runnable Quickstart** — verified end-to-end in a fresh venv from the built wheel.
- **Tutorial** — the full semantic-shift-over-time workflow (corpus → PPMI embeddings per slice → Procrustes alignment → shift detection → topic alignment), pointing at the presidential-speeches notebook and the gender-bias-in-Hungarian-media study.
- **Troubleshooting** page derived from the failure modes the docstrings surfaced.
- Fixed `installation.rst` (real GitHub URL + uv dev setup), rebuilt `examples.rst`, completed the API reference (added the Cython class), and fixed the README quickstart's undefined `your_corpus_iterator`.
- **Docs build with zero Sphinx warnings (was 77).**

### Supporting changes — please review
1. **Re-exports in subpackage `__init__.py`** so the documented imports (`from chronowords.algebra import SVDAlgebra`, etc.) work. They previously raised `ImportError` — the README example could not run. Additive and behaviour-preserving.
2. **Removed `sphinx-autodoc-typehints`** — it is deprecated (emits `RemovedInSphinx10` warnings) and mangles correctly-formed napoleon admonitions, which blocked zero-warnings. All code is fully type-annotated so autodoc renders types in signatures natively. Docs-only change.

### Flagged, not fixed
- `CountMinSketch.estimate_error` ignores its `confidence` argument (computes an unused `delta`). Documented honestly; left for the design-review phase.

## Verification
- `uv run pytest` — 48 passed
- `uv run pytest --doctest-modules src/chronowords` — 34 passed; CI-style `python -m doctest nmf.py` passes
- `uv run ty check src tests` — clean
- `uv run ruff check . && uv run ruff format --check .` — clean
- `cd docs && uv run make html` — build succeeded, **0 warnings**
- Quickstart run verbatim from a freshly `pip install`ed wheel in a throwaway venv

Part of the docs/design/tests hardening effort. **Do not merge** — review queue only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)